### PR TITLE
String.startsWith is not available in all browsers

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1033,7 +1033,7 @@ export default class InteractionManager extends EventEmitter
 
         const isTouch = (e.type === 'touchend' || e.pointerType === 'touch');
 
-        const isMouse = (e.type.startsWith('mouse') || e.pointerType === 'mouse');
+        const isMouse = (/^mouse/.test(e.type) || e.pointerType === 'mouse');
 
         // Pointers and Touches
         if (hit)


### PR DESCRIPTION
but used in the refactoring of the InteractionManager, which breaks up events for me in Safari 8.0.6. I did a global search and it's the only place where it is used so I simply replaced it with a straightforward RegExp.